### PR TITLE
Fix for potential empty array in watched_keys

### DIFF
--- a/lib/redis/bitops/sparse_bitmap.rb
+++ b/lib/redis/bitops/sparse_bitmap.rb
@@ -113,7 +113,7 @@ class Redis
       
         if Redis::Bitops.configuration.transaction_level == current_level
           watched_keys = options[:watch]
-          @redis.watch(watched_keys) if watched_keys
+          @redis.watch(watched_keys) if watched_keys && watched_keys != []
           @redis.multi(&block)
         else
           block.call

--- a/spec/redis/bitops/sparse_bitmap_spec.rb
+++ b/spec/redis/bitops/sparse_bitmap_spec.rb
@@ -9,6 +9,7 @@ describe Redis::Bitops::SparseBitmap, redis_cleanup: true, redis_key_prefix: "rs
   let(:a) { redis.sparse_bitmap("rsb:a", bytes_per_chunk) }
   let(:b) { redis.sparse_bitmap("rsb:b", bytes_per_chunk) }
   let(:c) { redis.sparse_bitmap("rsb:c", bytes_per_chunk) }
+  let(:empty) { redis.sparse_bitmap("rsb:empty", bytes_per_chunk) }
   let(:result) { redis.sparse_bitmap("rsb:output", bytes_per_chunk) }
 
   describe "edge cases" do
@@ -52,12 +53,22 @@ describe Redis::Bitops::SparseBitmap, redis_cleanup: true, redis_key_prefix: "rs
         result << (a | b)
         result.bitcount.should == 5
       end
+
+      it "handles empty bitmaps" do
+        result << (empty | empty)
+        result.bitcount.should == 0
+      end
     end
   
     describe "#operator &" do 
       it "handles bits around chunk boundaries" do
         result << (a & b)
         result.bitcount.should == 3
+      end
+
+      it "handles empty bitmaps" do
+        result << (empty & empty)
+        result.bitcount.should == 0
       end
     end
   
@@ -79,6 +90,11 @@ describe Redis::Bitops::SparseBitmap, redis_cleanup: true, redis_key_prefix: "rs
       it "handles bits around chunk boundaries" do
         result << (a ^ b)
         result.bitcount.should == 2
+      end
+
+      it "handles empty bitmaps" do
+        result << (empty ^ empty)
+        result.bitcount.should == 0
       end
     end
 


### PR DESCRIPTION
I encountered an error when the result of a bitwise operator is an empty bitmap.  It seems that bitcount and other resulting operations failed with:

`Redis::CommandError: ERR wrong number of arguments for 'watch' command`

Ensuring that the watch command isn't operating on an empty array fixed the issue.

Includes tests.
