### PR TITLE
Don't use transactions (multi) for bitops

### DIFF
--- a/lib/redis/bitops/sparse_bitmap.rb
+++ b/lib/redis/bitops/sparse_bitmap.rb
@@ -40,9 +40,11 @@ class Redis
       
         all_keys = self.chunk_keys + (operands.map(&:chunk_keys).flatten! || [])
         unique_chunk_numbers = Set.new(chunk_numbers(all_keys))
-      
-        unique_chunk_numbers.each do |i|
-          @redis.bitop(op, result.chunk_key(i), self.chunk_key(i), *operands.map { |o| o.chunk_key(i) })
+
+        @redis.pipelined do
+          unique_chunk_numbers.each do |i|
+            @redis.bitop(op, result.chunk_key(i), self.chunk_key(i), *operands.map { |o| o.chunk_key(i) })
+          end
         end
         result
       end

--- a/lib/redis/bitops/sparse_bitmap.rb
+++ b/lib/redis/bitops/sparse_bitmap.rb
@@ -41,10 +41,8 @@ class Redis
         all_keys = self.chunk_keys + (operands.map(&:chunk_keys).flatten! || [])
         unique_chunk_numbers = Set.new(chunk_numbers(all_keys))
       
-        maybe_multi(level: :bitmap, watch: all_keys) do
-          unique_chunk_numbers.each do |i|
-            @redis.bitop(op, result.chunk_key(i), self.chunk_key(i), *operands.map { |o| o.chunk_key(i) })
-          end
+        unique_chunk_numbers.each do |i|
+          @redis.bitop(op, result.chunk_key(i), self.chunk_key(i), *operands.map { |o| o.chunk_key(i) })
         end
         result
       end


### PR DESCRIPTION
If you use a bitop against a frequently changing bitmap, the multi can be cancelled because the underlying key tracked by watch will change and invalidate the transaction.  The bitop will then return invalid results (0).  This removes the transaction block.  Unknown if this is dangerous if the bitmap is in the process of being copied.  Causes bitops to not be strongly consistent.

This also pipelines bit operations to increase speed.  In testing large bitmaps saw a ~50x increase in speed
by pipelining operations.
